### PR TITLE
Use browser theme preference for favicon, logo, and theme

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,12 +2,26 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" href="/favicon.png" />
+  <link id="favicon" rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NITC Alumni Connect Portal</title>
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Dynamically switch favicon based on browser theme
+      function setFavicon() {
+        const darkFavicon = '/favicon-dark.png';
+        const lightFavicon = '/favicon.png';
+        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const favicon = document.getElementById('favicon');
+        if (favicon) {
+          favicon.href = prefersDark ? darkFavicon : lightFavicon;
+        }
+      }
+      setFavicon();
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', setFavicon);
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/client/src/components/home/components/DashboardHeader.jsx
+++ b/client/src/components/home/components/DashboardHeader.jsx
@@ -39,7 +39,6 @@ const LogoContainer = styled('div')({
 
 function DashboardHeader({ setAuthToken, logo, title, menuOpen, onToggleMenu, user }) {
 
-  const theme = useTheme();
   const navigate = useNavigate();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const menuOpenState = Boolean(anchorEl);
@@ -52,7 +51,6 @@ function DashboardHeader({ setAuthToken, logo, title, menuOpen, onToggleMenu, us
     (isExpanded) => {
       const expandMenuActionText = 'Expand';
       const collapseMenuActionText = 'Collapse';
-
       return (
         <Tooltip
           title={`${isExpanded ? collapseMenuActionText : expandMenuActionText} menu`}
@@ -73,11 +71,9 @@ function DashboardHeader({ setAuthToken, logo, title, menuOpen, onToggleMenu, us
     [handleMenuOpen],
   );
 
-  // Determine which logo to display based on the theme mode
-  //   const currentLogo = theme.palette.mode === 'dark' ? darkLogoWithFont : whiteLogoWithFont;
-
-  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: light)');
-  const currentLogo = prefersDarkMode ? darkLogoWithFont : whiteLogoWithFont;
+  // Use browser theme preference for logo
+  const prefersDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const currentLogo = prefersDarkMode ? whiteLogoWithFont : darkLogoWithFont ;
 
   const handleAvatarClick = (event) => {
     setAnchorEl(event.currentTarget);

--- a/client/src/components/shared-theme/AppTheme.jsx
+++ b/client/src/components/shared-theme/AppTheme.jsx
@@ -10,33 +10,29 @@ import { surfacesCustomizations } from './customizations/surfaces';
 import { colorSchemes, typography, shadows, shape } from './themePrimitives';
 
 function AppTheme(props) {
-  const { children, disableCustomTheme, themeComponents } = props;
+  const { children, themeComponents } = props;
+  // Detect browser color scheme preference
+  const prefersDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   const theme = React.useMemo(() => {
-    return disableCustomTheme
-      ? {}
-      : createTheme({
-          // For more details about CSS variables configuration, see https://mui.com/material-ui/customization/css-theme-variables/configuration/
-          cssVariables: {
-            colorSchemeSelector: 'data-mui-color-scheme',
-            cssVarPrefix: 'template',
-          },
-          colorSchemes, // Recently added in v6 for building light & dark mode app, see https://mui.com/material-ui/customization/palette/#color-schemes
-          typography,
-          shadows,
-          shape,
-          components: {
-            ...inputsCustomizations,
-            ...dataDisplayCustomizations,
-            ...feedbackCustomizations,
-            ...navigationCustomizations,
-            ...surfacesCustomizations,
-            ...themeComponents,
-          },
-        });
-  }, [disableCustomTheme, themeComponents]);
-  if (disableCustomTheme) {
-    return <React.Fragment>{children}</React.Fragment>;
-  }
+    return createTheme({
+      cssVariables: {
+        colorSchemeSelector: 'data-mui-color-scheme',
+        cssVarPrefix: 'template',
+      },
+      colorSchemes: prefersDarkMode ? { dark: colorSchemes.dark } : { light: colorSchemes.light },
+      typography,
+      shadows,
+      shape,
+      components: {
+        ...inputsCustomizations,
+        ...dataDisplayCustomizations,
+        ...feedbackCustomizations,
+        ...navigationCustomizations,
+        ...surfacesCustomizations,
+        ...themeComponents,
+      },
+    });
+  }, [prefersDarkMode, themeComponents]);
   return (
     <ThemeProvider theme={theme} disableTransitionOnChange>
       {children}
@@ -46,10 +42,6 @@ function AppTheme(props) {
 
 AppTheme.propTypes = {
   children: PropTypes.node,
-  /**
-   * This is for the docs site. You can ignore it or remove it.
-   */
-  disableCustomTheme: PropTypes.bool,
   themeComponents: PropTypes.object,
 };
 


### PR DESCRIPTION
Updated index.html to dynamically switch favicon based on browser color scheme. DashboardHeader and AppTheme now use browser theme preference to select the appropriate logo and Material UI color scheme, removing unused theme props and logic.